### PR TITLE
Rebrand as Open Source Hunt

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Features, Bug Reports, Questions
-    url: https://github.com/oss-hunt/oss-hunt/discussions
+    url: https://github.com/open-source-hunt/open-source-hunt/discussions
     about: Our preferred starting point if you have any questions or suggestions about configuration, features or behavior.

--- a/LICENSE
+++ b/LICENSE
@@ -24,8 +24,8 @@ Covenants of Licensor
 
 In consideration of the right to use this License's text and the "Business Source License" name and trademark, Licensor covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
 
-Licensor: Copyright © 2025 OSS Hunt, Inc. All Rights Reserved.
-Licensed Work: The software codebase for OSS Hunt, located at https://github.com/oss-hunt/oss-hunt.
+Licensor: Copyright © 2025 Open Source Hunt, Inc. All Rights Reserved.
+Licensed Work: The software codebase for Open Source Hunt, located at https://github.com/open-source-hunt/open-source-hunt.
 Additional Use Grant: None.
 Change Date: Five years from the date this version of the Licensed Work is first made publicly available on GitHub, whether by publishing a release or pushing a commit to a public branch. For example, a commit made public on January 1, 2025, will transition to GPLv3 on January 1, 2030. Commits made later will have their own five-year transition period.
 Change License: GPLv3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# OSS Hunt
+# Open Source Hunt
 
 Welcome 👋
 
 ## License
 
-OSS Hunt is released under the Business Source License (BSL). Five years from the date this version of the Licensed Work is first made publicly available on GitHub—whether by publishing a release or pushing a commit to a public branch—it will transition to the GPLv3 license. See the LICENSE file for details.
+Open Source Hunt is released under the Business Source License (BSL). Five years from the date this version of the Licensed Work is first made publicly available on GitHub—whether by publishing a release or pushing a commit to a public branch—it will transition to the GPLv3 license. See the LICENSE file for details.


### PR DESCRIPTION
This is better.